### PR TITLE
Add kilometers, default to kilometers, show all 3 ranges in CLI

### DIFF
--- a/lib/tesla-api/charge_state.rb
+++ b/lib/tesla-api/charge_state.rb
@@ -2,7 +2,7 @@ module TeslaAPI
 
   # Defines the current charge state of the vehicle
   class ChargeState < Data
-    MILE_IN_KM = 1.609
+    MILE_IN_KM = 1.609344
 
     attr_reader :battery_range_kilometers, :estimated_battery_range_kilometers, :ideal_battery_range_kilometers
 

--- a/lib/tesla-api/charge_state.rb
+++ b/lib/tesla-api/charge_state.rb
@@ -78,7 +78,6 @@ module TeslaAPI
     # @method supercharging?
     # @return [Boolean] charging via a Tesla SuperCharger
 
-    require 'pry'
     def initialize(data)
       ivar_from_data("charging_state",               "charging_state",         data)
       ivar_from_data("charging_to_max",              "charge_to_max_range",    data)

--- a/lib/tesla-api/charge_state.rb
+++ b/lib/tesla-api/charge_state.rb
@@ -2,6 +2,11 @@ module TeslaAPI
 
   # Defines the current charge state of the vehicle
   class ChargeState < Data
+    MILE_IN_KM = 1.609
+
+    attr_reader :estimated_battery_range_kilometers
+    attr_reader :battery_range_kilometers
+
     ##
     # @method charging_state
     # @return Charging state ("Complete", "Charging")
@@ -11,11 +16,19 @@ module TeslaAPI
     # @return [Boolean] true if currently performing a range charge
 
     ##
+    # @method battery_range_kilometers
+    # @return [Float] Rated kilometers for the current charge
+
+    ##
     # @method battery_range_miles
     # @return [Float] Rated miles for the current charge
 
     ##
-    # @method estimated_battry_range_miles
+    # @method estimated_battery_range_kilometers
+    # @return [Float] Range estimated from current driving
+
+    ##
+    # @method estimated_battery_range_miles
     # @return [Float] Range estimated from current driving
 
     ##
@@ -55,6 +68,10 @@ module TeslaAPI
     # @return [Float] Miles of range being added per hour
 
     ##
+    # @method charge_rate_kilometers_per_hour
+    # @return [Float] Kilometers of range being added per hour
+
+    ##
     # @method charge_port_open?
     # @return [Boolean] charge port open state
 
@@ -62,11 +79,12 @@ module TeslaAPI
     # @method supercharging?
     # @return [Boolean] charging via a Tesla SuperCharger
 
+    require 'pry'
     def initialize(data)
       ivar_from_data("charging_state",               "charging_state",         data)
       ivar_from_data("charging_to_max",              "charge_to_max_range",    data)
       ivar_from_data("battery_range_miles",          "battery_range",          data)
-      ivar_from_data("estimated_battry_range_miles", "est_battery_range",      data)
+      ivar_from_data("estimated_battery_range_miles", "est_battery_range",      data)
       ivar_from_data("ideal_battery_range_miles",    "ideal_battery_range",    data)
       ivar_from_data("battery_percentage",           "battery_level",          data)
       ivar_from_data("battery_current_flow",         "battery_current",        data)
@@ -78,6 +96,10 @@ module TeslaAPI
       ivar_from_data("charge_rate_miles_per_hour",   "charge_rate",            data)
       ivar_from_data("charge_port_open",             "charge_port_door_open",  data)
       ivar_from_data("supercharging",                "fast_charger_present",   data)
+
+      @battery_range_kilometers = (battery_range_miles * MILE_IN_KM).round(2)
+      @estimated_battery_range_kilometers = (estimated_battery_range_miles * MILE_IN_KM).round(2)
+      @ideal_battery_range_kilometers = (ideal_battery_range_miles * MILE_IN_KM).round(2)
 
       @charging        = charging_state == "Charging"
       @charge_complete = charging_state == "Complete"

--- a/lib/tesla-api/charge_state.rb
+++ b/lib/tesla-api/charge_state.rb
@@ -4,8 +4,7 @@ module TeslaAPI
   class ChargeState < Data
     MILE_IN_KM = 1.609
 
-    attr_reader :estimated_battery_range_kilometers
-    attr_reader :battery_range_kilometers
+    attr_reader :battery_range_kilometers, :estimated_battery_range_kilometers, :ideal_battery_range_kilometers
 
     ##
     # @method charging_state

--- a/lib/tesla-api/cli.rb
+++ b/lib/tesla-api/cli.rb
@@ -17,6 +17,7 @@ module TeslaAPI
     desc "range", "Gets the current rated range of the vehicle"
     def range
       display(vehicle.charge_state.battery_range_miles, "miles")
+      display(vehicle.charge_state.battery_range_kilometers, "kilometers")
     end
 
     desc "inside_temp", "Gets the inside temperature"

--- a/lib/tesla-api/cli.rb
+++ b/lib/tesla-api/cli.rb
@@ -22,12 +22,12 @@ module TeslaAPI
 
     desc "inside_temp", "Gets the inside temperature"
     def inside_temp
-      display(vehicle.climate_state.inside_temp_celcius, "C")
+      display(vehicle.climate_state.inside_temp_celsius, "C")
     end
 
     desc "outside_temp", "Gets the outside temperature"
     def outside_temp
-      display(vehicle.climate_state.outside_temp_celcius.inspect, "C")
+      display(vehicle.climate_state.outside_temp_celsius.inspect, "C")
     end
 
     desc "lock", "Locks the car doors"

--- a/lib/tesla-api/cli.rb
+++ b/lib/tesla-api/cli.rb
@@ -6,6 +6,7 @@ module TeslaAPI
 
     class_option :login
     class_option :password
+    option :miles, :type => :boolean, :desc => "Give ranges in miles instead of kilometers"
 
     def initialize(*args)
       super
@@ -14,10 +15,17 @@ module TeslaAPI
       @password = ENV["TESLA_API_PASSWORD"]
     end
 
-    desc "range", "Gets the current rated range of the vehicle"
+    desc "range", "Gets the current ranges of the vehicle"
     def range
-      display(vehicle.charge_state.battery_range_miles, "miles")
-      display(vehicle.charge_state.battery_range_kilometers, "kilometers")
+      if options[:miles]
+        puts "#{vehicle.charge_state.battery_range_miles} miles (rated)"
+        puts "#{vehicle.charge_state.estimated_battery_range_miles} miles (estimated)"
+        puts "#{vehicle.charge_state.ideal_battery_range_miles} miles (ideal)"
+      else
+        puts "#{vehicle.charge_state.battery_range_kilometers} kilometers (rated)"
+        puts "#{vehicle.charge_state.estimated_battery_range_kilometers} kilometers (estimated)"
+        puts "#{vehicle.charge_state.ideal_battery_range_kilometers} kilometers (ideal)"
+      end
     end
 
     desc "inside_temp", "Gets the inside temperature"

--- a/lib/tesla-api/climate_state.rb
+++ b/lib/tesla-api/climate_state.rb
@@ -3,20 +3,20 @@ module TeslaAPI
   #
   class ClimateState < Data
     ##
-    # @method inside_temp_celcius
-    # @return [Float] Temperature (celcius) inside the vehicle
+    # @method inside_temp_celsius
+    # @return [Float] Temperature (celsius) inside the vehicle
 
     ##
-    # @method outside_temp_celcius
-    # @return [Float] Temperature (celcius) outside the vehicle
+    # @method outside_temp_celsius
+    # @return [Float] Temperature (celsius) outside the vehicle
 
     ##
-    # @method driver_temp_setting_celcius
-    # @return [Float] Temperature (celcius) the driver has set
+    # @method driver_temp_setting_celsius
+    # @return [Float] Temperature (celsius) the driver has set
 
     ##
-    # @method passenger_temp_setting_celcius
-    # @return [Float] Temperature (celcius) the passenger has set
+    # @method passenger_temp_setting_celsius
+    # @return [Float] Temperature (celsius) the passenger has set
 
     ##
     # @method fan_speed
@@ -39,10 +39,10 @@ module TeslaAPI
     # @return [Boolean] if the fan is on
 
     def initialize(data)
-      ivar_from_data("inside_temp_celcius",            "inside_temp",            data)
-      ivar_from_data("outside_temp_celcius",           "outside_temp",           data)
-      ivar_from_data("driver_temp_setting_celcius",    "driver_temp_setting",    data)
-      ivar_from_data("passenger_temp_setting_celcius", "passenger_temp_setting", data)
+      ivar_from_data("inside_temp_celsius",            "inside_temp",            data)
+      ivar_from_data("outside_temp_celsius",           "outside_temp",           data)
+      ivar_from_data("driver_temp_setting_celsius",    "driver_temp_setting",    data)
+      ivar_from_data("passenger_temp_setting_celsius", "passenger_temp_setting", data)
       ivar_from_data("fan_speed",                      "fan_speed",              data)
 
       @auto_conditioning_on   = !!data["is_auto_conditioning_on"]

--- a/lib/tesla-api/private_api.rb
+++ b/lib/tesla-api/private_api.rb
@@ -22,9 +22,9 @@ module TeslaAPI
       end
     end
 
-    def set_temperature!(vehicle, driver_degrees_celcius, passenger_degrees_celcius)
-      command!(vehicle, "set_temps", :query => { :driver_degrees_celcius    => driver_degrees_celcius,
-                                                 :passenger_degrees_celcius => passenger_degrees_celcius })
+    def set_temperature!(vehicle, driver_degrees_celsius, passenger_degrees_celsius)
+      command!(vehicle, "set_temps", :query => { :driver_degrees_celsius    => driver_degrees_celsius,
+                                                 :passenger_degrees_celsius => passenger_degrees_celsius })
     end
 
     def open_roof!(vehicle, state)

--- a/lib/tesla-api/vehicle.rb
+++ b/lib/tesla-api/vehicle.rb
@@ -97,8 +97,8 @@ module TeslaAPI
     end
 
     # Sets the temperature for both the driver and passenger
-    def set_temperature!(driver_degrees_celcius, passenger_degrees_celcius)
-      tesla.set_temperature!(self, driver_degrees_celcius, passenger_degrees_celcius)
+    def set_temperature!(driver_degrees_celsius, passenger_degrees_celsius)
+      tesla.set_temperature!(self, driver_degrees_celsius, passenger_degrees_celsius)
     end
 
     # Opens the panoramic roof

--- a/test/test_charge_state.rb
+++ b/test/test_charge_state.rb
@@ -57,6 +57,14 @@ class ChargeStateTest < Test::Unit::TestCase
     assert_equal 70, charge_state.battery_percentage
   end
 
+  def test_ideal_battery_range_kilometers
+    assert_equal 328.48, charge_state.ideal_battery_range_kilometers
+  end
+
+  def test_ideal_battery_range_miles
+    assert_equal 204.15, charge_state.ideal_battery_range_miles
+  end
+
   def test_estimated_battery_range_kilometers
     assert_equal 231.63, charge_state.estimated_battery_range_kilometers
   end

--- a/test/test_charge_state.rb
+++ b/test/test_charge_state.rb
@@ -57,12 +57,20 @@ class ChargeStateTest < Test::Unit::TestCase
     assert_equal 70, charge_state.battery_percentage
   end
 
+  def test_estimated_battery_range_kilometers
+    assert_equal 231.63, charge_state.estimated_battery_range_kilometers
+  end
+
   def test_estimated_battery_range_miles
-    assert_equal 143.96, charge_state.estimated_battry_range_miles
+    assert_equal 143.96, charge_state.estimated_battery_range_miles
   end
 
   def test_battery_range_miles
     assert_equal 177.38, charge_state.battery_range_miles
+  end
+
+  def test_battery_range_kilometers
+    assert_equal 285.40, charge_state.battery_range_kilometers
   end
 
   def test_charging_to_max

--- a/test/test_charge_state.rb
+++ b/test/test_charge_state.rb
@@ -58,7 +58,7 @@ class ChargeStateTest < Test::Unit::TestCase
   end
 
   def test_ideal_battery_range_kilometers
-    assert_equal 328.48, charge_state.ideal_battery_range_kilometers
+    assert_equal 328.55, charge_state.ideal_battery_range_kilometers
   end
 
   def test_ideal_battery_range_miles
@@ -66,7 +66,7 @@ class ChargeStateTest < Test::Unit::TestCase
   end
 
   def test_estimated_battery_range_kilometers
-    assert_equal 231.63, charge_state.estimated_battery_range_kilometers
+    assert_equal 231.68, charge_state.estimated_battery_range_kilometers
   end
 
   def test_estimated_battery_range_miles
@@ -78,7 +78,7 @@ class ChargeStateTest < Test::Unit::TestCase
   end
 
   def test_battery_range_kilometers
-    assert_equal 285.40, charge_state.battery_range_kilometers
+    assert_equal 285.47, charge_state.battery_range_kilometers
   end
 
   def test_charging_to_max

--- a/test/test_climate_state.rb
+++ b/test/test_climate_state.rb
@@ -13,20 +13,20 @@ class ClimateStateTest < Test::Unit::TestCase
     end
   end
 
-  def test_inside_temp_celcius
-    assert_equal nil, climate_state.inside_temp_celcius
+  def test_inside_temp_celsius
+    assert_equal nil, climate_state.inside_temp_celsius
   end
 
-  def test_outside_temp_celcius
-    assert_equal nil, climate_state.outside_temp_celcius
+  def test_outside_temp_celsius
+    assert_equal nil, climate_state.outside_temp_celsius
   end
 
-  def test_driver_temp_setting_celcius
-    assert_equal 23.1, climate_state.driver_temp_setting_celcius
+  def test_driver_temp_setting_celsius
+    assert_equal 23.1, climate_state.driver_temp_setting_celsius
   end
 
-  def test_passenger_temp_setting_celcius
-    assert_equal 23.1, climate_state.passenger_temp_setting_celcius
+  def test_passenger_temp_setting_celsius
+    assert_equal 23.1, climate_state.passenger_temp_setting_celsius
   end
 
   def test_fan_speed


### PR DESCRIPTION
I've added a few options to show rated, ideal and estimated ranges from the CLI. Also, defaults to kilometers and allows a `--miles` option.
